### PR TITLE
Correct Australian reference and flag

### DIFF
--- a/currencies.csv
+++ b/currencies.csv
@@ -75,7 +75,7 @@ Id,Name,Code,Simbol,Country,Flag
 76,Zambian kwacha,ZMW,ZK,Zambia,zambia.png
 77,Tanzanian shilling,TZS,Sh,Tanzania,tanzania.png
 78,Vietnamese đồng,VND,₫,Vietnam,vietnam.png
-79,Australian dollar,AUD,$,Tuvalu,tuvalu.png
+79,Australian dollar,AUD,$,Australia,australia.png
 80,Israeli new shekel,ILS,₪,Palestine,israel.png
 81,Ghana cedi,GHS,₵,Ghana,ghana.png
 82,Guyanese dollar,GYD,$,Guyana,guyana.png


### PR DESCRIPTION
The Australian entry had a reference to Tuvalu and displayed the Tuvalian flag. This commit corrects that.
